### PR TITLE
fixed modules bug:  bcrypt was initializing twice so code would break while seeding

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -3,9 +3,9 @@ const bcrypt = require('bcrypt');
 const sequelize = require('../config/connection');
 
 class User extends Model {
-  checkPassword(loginPw) {
-    return bcrypt.compareSync(loginPw, this.password);
-  }
+  // checkPassword(loginPw) {
+  //   return bcrypt.compareSync(loginPw, this.password);
+  // }
 }
 
 User.init(
@@ -47,12 +47,14 @@ User.init(
         type: DataTypes.BOOLEAN,
         allowNull: false,
     },
-    hooks: {
-      beforeCreate: async (newUserData) => {
-        newUserData.password = await bcrypt.hash(newUserData.password, 10);
-        return newUserData;
-      },
-    },
+    // hooks: {
+    //   beforeCreate: async (newUserData) => {
+    //     newUserData.password = await bcrypt.hash(newUserData.password, 10);
+    //     return newUserData;
+    //   },
+    // },
+  },
+  {
     sequelize,
     timestamps: false,
     freezeTableName: true,

--- a/models/index.js
+++ b/models/index.js
@@ -1,4 +1,14 @@
 const User = require('./User');
-//node const Truck = require('./truck')
-module.exports = { User };
+const Truck = require('./truck')
+
 //module.exports = { Truck };
+
+User.hasMany(Truck, {
+    foreignKey: 'id',
+    onDelete: 'CASCADE'
+  });
+
+  Truck.belongsTo(User, {
+    foreignKey: 'id'
+  });
+module.exports = { User, Truck };

--- a/models/truck.js
+++ b/models/truck.js
@@ -51,11 +51,11 @@ Truck.init(
     },
     driver_id: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
       },
         truck_name: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
       },
   },
   {


### PR DESCRIPTION
so... I fixed the bug that had to do with the modules. The modules did not work when seeding the data. What I think happened was that on each one of the models both had the same line of code for bcrypt, and when seeding the code would break. I will be pushing out a cleaner fix, but for now I commented out the one of the brcrpt initializer so at least the models are functional.
